### PR TITLE
fix 2025/1/3 修复eccang错误码为10001的年份问题

### DIFF
--- a/somle-esb/src/main/java/com/somle/esb/job/EccangOrderPlatformPayDataJob.java
+++ b/somle-esb/src/main/java/com/somle/esb/job/EccangOrderPlatformPayDataJob.java
@@ -2,11 +2,7 @@ package com.somle.esb.job;
 
 
 import com.somle.eccang.model.EccangOrderVO;
-import com.somle.eccang.service.EccangService;
-import com.somle.esb.model.Domain;
 import com.somle.esb.model.OssData;
-import com.somle.esb.service.EsbService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -24,7 +20,7 @@ public class EccangOrderPlatformPayDataJob extends EccangDataJob {
                         .platformPaidDateEnd(beforeYesterdayLastSecond)
                         .build())
                     .build(),
-                beforeYesterday.getYear()
+                null
             )
             .forEach(page -> {
                 OssData data = OssData.builder()

--- a/somle-esb/src/main/java/com/somle/esb/job/EccangOrderPlatformShipDataJob.java
+++ b/somle-esb/src/main/java/com/somle/esb/job/EccangOrderPlatformShipDataJob.java
@@ -20,7 +20,7 @@ public class EccangOrderPlatformShipDataJob extends EccangDataJob {
                         .platformShipDateEnd(beforeYesterdayLastSecond)
                         .build())
                     .build(),
-                beforeYesterday.getYear()
+                null
             )
             .forEach(page -> {
                 OssData data = OssData.builder()

--- a/somle-esb/src/main/java/com/somle/esb/job/EccangOrderSysCreateDataJob.java
+++ b/somle-esb/src/main/java/com/somle/esb/job/EccangOrderSysCreateDataJob.java
@@ -2,12 +2,7 @@ package com.somle.esb.job;
 
 
 import com.somle.eccang.model.EccangOrderVO;
-import com.somle.eccang.service.EccangService;
-import com.somle.esb.model.Domain;
 import com.somle.esb.model.OssData;
-import com.somle.esb.service.EsbService;
-import com.somle.framework.common.util.general.CoreUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,7 +20,7 @@ public class EccangOrderSysCreateDataJob extends EccangDataJob {
                         .dateCreateSysEnd(beforeYesterdayLastSecond)
                         .build())
                     .build(),
-                beforeYesterday.getYear()
+                null
             )
             .forEach(page -> {
                 OssData data = OssData.builder()

--- a/somle-esb/src/main/java/com/somle/esb/job/EccangOrderWarehouseShipDataJob.java
+++ b/somle-esb/src/main/java/com/somle/esb/job/EccangOrderWarehouseShipDataJob.java
@@ -20,7 +20,7 @@ public class EccangOrderWarehouseShipDataJob extends EccangDataJob {
                         .warehouseShipDateEnd(beforeYesterdayLastSecond)
                         .build())
                     .build(),
-                beforeYesterday.getYear()
+                null
             )
             .forEach(page -> {
                 OssData data = OssData.builder()


### PR DESCRIPTION
1、制空year参数，由于缺少2025年订单导致报错，实际有创建的开始+结束时间已足够。已测试
