### PR TITLE
fix 2025/01/06 整合eccang归档信息，修复eccang响应体空的情况的异常处理

### DIFF
--- a/somle-eccang/src/main/java/com/somle/eccang/model/EccangResponse.java
+++ b/somle-eccang/src/main/java/com/somle/eccang/model/EccangResponse.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@ToString
 public class EccangResponse {
     private String code;
     private String message;

--- a/somle-eccang/src/main/java/com/somle/eccang/model/exception/EccangResponseException.java
+++ b/somle-eccang/src/main/java/com/somle/eccang/model/exception/EccangResponseException.java
@@ -1,0 +1,30 @@
+package com.somle.eccang.model.exception;
+
+
+import com.somle.eccang.model.EccangResponse;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 自定义异常：用于处理 Eccang 特定的错误（如错误代码 300 和 10001）
+ */
+@Data
+public class EccangResponseException extends RuntimeException {
+
+    // 用于标识错误的额外信息
+    private final List<EccangResponse.EccangError> eccangError;
+
+    // 构造函数
+    public EccangResponseException(List<EccangResponse.EccangError> eccangError) {
+        super("Eccang error occurred, ErrorCode: " + eccangError.stream()
+            .map(EccangResponse.EccangError::getErrorCode)  // 提取 ErrorCode
+            .collect(Collectors.toSet())
+            + ", Message: " + eccangError.stream()
+            .map(EccangResponse.EccangError::getErrorMsg)  // 提取 ErrorMsg
+            .collect(Collectors.toSet()));
+        this.eccangError = eccangError;
+    }
+
+}

--- a/somle-eccang/src/main/java/com/somle/eccang/service/EccangService.java
+++ b/somle-eccang/src/main/java/com/somle/eccang/service/EccangService.java
@@ -3,6 +3,7 @@ package com.somle.eccang.service;
 import cn.hutool.core.collection.CollUtil;
 import com.somle.eccang.model.*;
 import com.somle.eccang.model.EccangResponse.EccangPage;
+import com.somle.eccang.model.exception.EccangResponseException;
 import com.somle.eccang.repository.EccangTokenRepository;
 import com.somle.framework.common.util.general.Limiter;
 import com.somle.framework.common.util.json.JSONObject;
@@ -42,7 +43,7 @@ public class EccangService {
 
 
     private EccangToken token;
-    private int pageSize = 100;
+    private final int pageSize = 100;
     private Limiter limiter = new Limiter(20);
 
     @Autowired
@@ -165,16 +166,12 @@ public class EccangService {
             case "common.error.code.9999":
                 throw new RuntimeException("Eccang return invalid response: " + response.getBizContent(EccangResponse.EccangError.class));
             case "300":
-                    response.getBizContentList(EccangResponse.EccangError.class).stream()
-                        .filter(e -> "10001".equals(e.getErrorCode()))  // 过滤出 errorCode 为 "10001" 的错误
-                        .findFirst().ifPresent(e -> {
-                        // 如果找到了匹配的错误，记录日志并清空业务内容
-                        log.info("Eccang returned error code 10001: Current year data is archived, skipping...");
-                        response.setBizContent(null);  // 清空业务内容
-                    });
-                    log.warn("当前响应体不含归档数据,选择跳过,original response = {}" ,response);
-                    if (response.getBizContent() == null)return;
-                throw new RuntimeException("Error message from eccang: {}" + response.getBizContentList(EccangResponse.EccangError.class));
+                List<EccangResponse.EccangError> errors = response.getBizContentList(EccangResponse.EccangError.class);
+                if (errors.isEmpty()) {
+                    throw new RuntimeException("response code is 300 but errors is empty,Error message from response: " + response);
+                }else {
+                    throw new EccangResponseException(errors);
+                }
             case "429":
                 throw new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS, "Too many requests, please try again later.");
             default:
@@ -192,10 +189,10 @@ public class EccangService {
         payload.put("page", 1);
         payload.put("page_size", pageSize);
         return Stream.iterate(
-            getPage(payload, endpoint),
+            getPage(payload, endpoint), Objects::nonNull,
             bizContent -> {
                 if (bizContent.hasNext()) {
-                    log.debug("have next,eccang page = {}",bizContent);
+                    log.debug("have next,当前进度：{}/{}", (bizContent.getPage() - 1) * pageSize + bizContent.getData().size(), bizContent.getTotal());
                     payload.put("page", bizContent.getPage() + 1);
                     return getPage(payload, endpoint);
                 } else {
@@ -203,7 +200,7 @@ public class EccangService {
                     return null;
                 }
             }
-        ).takeWhile(n -> n != null);
+        );
         // );
     }
 
@@ -304,7 +301,19 @@ public class EccangService {
 
     public Stream<EccangPage> getOrderArchivePages(EccangOrderVO orderParams, Integer year) {
         orderParams.setYear(year);
-        return getOrderUnarchivePages(orderParams);
+        Stream<EccangPage> stream;
+        try {
+            stream = getOrderUnarchivePages(orderParams);
+        } catch (EccangResponseException e) {
+            for (EccangResponse.EccangError eccangError : e.getEccangError()) {
+                if (eccangError.getErrorCode().equals("10001")){
+                    log.info("当前{}年不存在归档信息,跳过",year);
+                    return Stream.empty();//跳过
+                }
+            }
+            throw e;
+        }
+        return stream;
     }
 
 

--- a/somle-eccang/src/test/java/com/somle/eccang/service/EccangServiceTest.java
+++ b/somle-eccang/src/test/java/com/somle/eccang/service/EccangServiceTest.java
@@ -1,28 +1,17 @@
 package com.somle.eccang.service;
 
-import com.somle.eccang.model.EccangOrderVO;
 import com.somle.eccang.model.EccangToken;
 import com.somle.eccang.repository.EccangTokenRepository;
 import com.somle.framework.common.util.json.JSONObject;
 import com.somle.framework.common.util.json.JsonUtils;
 import com.somle.framework.test.core.ut.BaseMockitoUnitTest;
-import com.somle.framework.test.core.ut.BaseSpringTest;
-import com.somle.framework.test.core.ut.BaseSpringUnitTest;
-import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.messaging.MessageChannel;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -82,4 +71,24 @@ public class EccangServiceTest extends BaseMockitoUnitTest {
 //        var actual = service.requestBody(EccangOrderVO.builder().build(), "get");
 //        assertEquals(expected, actual);
 //    }
+
+    @Test
+    void getOrderArchivePages(){
+//        EccangOrderVO.builder()
+//            .condition(EccangOrderVO.Condition.builder()
+//                .platformPaidDateStart(beforeYesterdayFirstSecond)
+//                .platformPaidDateEnd(beforeYesterdayLastSecond)
+//                .build())
+//            .build(),
+//            beforeYesterday.getYear()
+//        LocalDateTimeUtils.getToday().minusDays(3)
+//        EccangOrderVO.builder()
+//            .condition(EccangOrderVO.Condition.builder()
+//                .platformPaidDateStart()
+//                .platformPaidDateEnd(beforeYesterdayLastSecond)
+//                .build())
+//            .build(),
+//            beforeYesterday.getYear()
+//        service.getOrderPlusArchivePages()
+    }
 }

--- a/somle-esb/src/main/java/com/somle/esb/job/EccangOrderPlatformPayDataJob.java
+++ b/somle-esb/src/main/java/com/somle/esb/job/EccangOrderPlatformPayDataJob.java
@@ -20,7 +20,7 @@ public class EccangOrderPlatformPayDataJob extends EccangDataJob {
                         .platformPaidDateEnd(beforeYesterdayLastSecond)
                         .build())
                     .build(),
-                null
+                beforeYesterday.getYear()
             )
             .forEach(page -> {
                 OssData data = OssData.builder()

--- a/somle-esb/src/main/java/com/somle/esb/job/EccangOrderPlatformShipDataJob.java
+++ b/somle-esb/src/main/java/com/somle/esb/job/EccangOrderPlatformShipDataJob.java
@@ -20,7 +20,7 @@ public class EccangOrderPlatformShipDataJob extends EccangDataJob {
                         .platformShipDateEnd(beforeYesterdayLastSecond)
                         .build())
                     .build(),
-                null
+                beforeYesterday.getYear()
             )
             .forEach(page -> {
                 OssData data = OssData.builder()

--- a/somle-esb/src/main/java/com/somle/esb/job/EccangOrderSysCreateDataJob.java
+++ b/somle-esb/src/main/java/com/somle/esb/job/EccangOrderSysCreateDataJob.java
@@ -20,7 +20,7 @@ public class EccangOrderSysCreateDataJob extends EccangDataJob {
                         .dateCreateSysEnd(beforeYesterdayLastSecond)
                         .build())
                     .build(),
-                null
+                beforeYesterday.getYear()
             )
             .forEach(page -> {
                 OssData data = OssData.builder()

--- a/somle-esb/src/main/java/com/somle/esb/job/EccangOrderWarehouseShipDataJob.java
+++ b/somle-esb/src/main/java/com/somle/esb/job/EccangOrderWarehouseShipDataJob.java
@@ -20,7 +20,7 @@ public class EccangOrderWarehouseShipDataJob extends EccangDataJob {
                         .warehouseShipDateEnd(beforeYesterdayLastSecond)
                         .build())
                     .build(),
-                null
+                beforeYesterday.getYear()
             )
             .forEach(page -> {
                 OssData data = OssData.builder()


### PR DESCRIPTION
1、当前不含归档数据的时候,选择跳过。
2、存在归档数据的时候正常返回。
3、增加日志信息跟踪，之后的请求不抛出堆栈信息。
已测试2022年数据，含归档信息，日志正常。