### PR TITLE
fix 停止hs属性向eccang同步。注销EccangProduct映射类的hs属性。

### DIFF
--- a/somle-eccang/src/main/java/com/somle/eccang/model/EccangProduct.java
+++ b/somle-eccang/src/main/java/com/somle/eccang/model/EccangProduct.java
@@ -61,7 +61,7 @@ public class EccangProduct {
     private Integer operationType;
     private Integer productStatus;
     private Integer saleStatus;
-    private String hsCode;
+//    private String hsCode;//暂停同步该属性
     private Float productLength;
     private Float productWidth;
     private Float productHeight;

--- a/somle-esb/src/main/java/com/somle/esb/converter/ErpToEccangConverter.java
+++ b/somle-esb/src/main/java/com/somle/esb/converter/ErpToEccangConverter.java
@@ -178,7 +178,7 @@ public class ErpToEccangConverter {
         eccangProduct.setFboTaxRate(customRuleDTO.getTaxRate());
         eccangProduct.setPdOverseaTypeCn(customRuleDTO.getDeclaredType());
         eccangProduct.setProductImgUrlList(Collections.singletonList(customRuleDTO.getProductImageUrl()));
-        eccangProduct.setHsCode(customRuleDTO.getHscode());
+//        eccangProduct.setHsCode(customRuleDTO.getHscode());//暂停向eccang同步该属性
         eccangProduct.setDefaultSupplierCode("默认供应商");
         // 设置物流属性
         Integer logisticAttribute = customRuleDTO.getLogisticAttribute();


### PR DESCRIPTION
已测试。海关规则修改后，eccang同步数据正常。