### PR TITLE
fix 海关规则中：对于CN的规则的修改，默认覆盖一个基类产品（无国别）。

### DIFF
--- a/somle-esb/src/main/java/com/somle/esb/converter/ErpToEccangConverter.java
+++ b/somle-esb/src/main/java/com/somle/esb/converter/ErpToEccangConverter.java
@@ -1,10 +1,10 @@
 package com.somle.esb.converter;
 
 import cn.hutool.core.collection.CollectionUtil;
+import cn.hutool.core.text.CharSequenceUtil;
 import cn.hutool.core.util.ObjUtil;
 import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.ReflectUtil;
-import cn.hutool.core.util.StrUtil;
 import cn.iocoder.yudao.framework.common.enums.enums.DictTypeConstants;
 import cn.iocoder.yudao.framework.common.exception.util.ThrowUtil;
 import cn.iocoder.yudao.framework.common.util.collection.MapUtils;
@@ -14,10 +14,10 @@ import cn.iocoder.yudao.module.system.api.dept.DeptApi;
 import cn.iocoder.yudao.module.system.api.dept.dto.DeptLevelRespDTO;
 import cn.iocoder.yudao.module.system.api.dept.dto.DeptRespDTO;
 import cn.iocoder.yudao.module.system.api.dict.DictDataApi;
-import cn.iocoder.yudao.module.system.api.dict.dto.DictDataRespDTO;
 import cn.iocoder.yudao.module.system.api.user.AdminUserApi;
 import cn.iocoder.yudao.module.system.api.user.dto.AdminUserRespDTO;
-import com.somle.eccang.model.*;
+import com.somle.eccang.model.EccangCategory;
+import com.somle.eccang.model.EccangProduct;
 import com.somle.eccang.service.EccangService;
 import com.somle.esb.enums.TenantId;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -102,6 +102,7 @@ public class ErpToEccangConverter {
 //        product.setUserOrganizationId(organization.getId());
 //        return product;
 //    }
+
     /**
      * 将ERP产品列表转换为完整的Eccang产品列表。
      *
@@ -132,22 +133,25 @@ public class ErpToEccangConverter {
      * 将单个ERP产品转换为Eccang产品。
      *
      * @param customRuleDTO ERP产品对象
-     * @param userMap 用户信息映射
+     * @param userMap       用户信息映射
      * @return 转换后的Eccang产品对象
      */
     private EccangProduct customRuleToProduct(ErpCustomRuleDTO customRuleDTO, Map<Long, AdminUserRespDTO> userMap) {
         EccangProduct eccangProduct = new EccangProduct();
         eccangProduct.setPdDeclarationStatement(customRuleDTO.getId());
-        // 设置SKU和标题
+
         Integer countryCode = customRuleDTO.getCountryCode();
-        if (ObjUtil.isNotEmpty(countryCode)) {
-            DictDataRespDTO dictData = dictDataApi.getDictData(DictTypeConstants.COUNTRY_CODE, String.valueOf(countryCode));
-            if (StrUtil.isNotBlank(customRuleDTO.getBarCode())) {
-                eccangProduct.setProductTitle(customRuleDTO.getProductName() + "-" + getCountrySuffix(dictData.getLabel()));
-                eccangProduct.setProductTitleEn(customRuleDTO.getBarCode() + "-" + getCountrySuffix(dictData.getLabel()));
-                eccangProduct.setProductSku(customRuleDTO.getBarCode() + "-" + getCountrySuffix(dictData.getLabel()));
-            }
-        }
+        String countrySuffix = ObjectUtil.isNotEmpty(countryCode)
+            ? getCountrySuffix(dictDataApi.getDictData(DictTypeConstants.COUNTRY_CODE, String.valueOf(countryCode)).getLabel())
+            : "";
+
+        String barCode = customRuleDTO.getBarCode();
+        String productName = customRuleDTO.getProductName();
+        String suffix = countrySuffix.isEmpty() ? "" : "-" + countrySuffix;
+
+        eccangProduct.setProductTitle(productName + suffix);
+        eccangProduct.setProductTitleEn(CharSequenceUtil.isNotBlank(barCode) ? barCode + suffix : barCode);
+        eccangProduct.setProductSku(CharSequenceUtil.isNotBlank(barCode) ? barCode + suffix : barCode);
         // 设置货币代码
         Optional.ofNullable(customRuleDTO.getDeclaredValueCurrencyCode())
             .map(String::valueOf)
@@ -264,8 +268,6 @@ public class ErpToEccangConverter {
     }
 
 
-
-
     public EccangCategory toEccang(String deptId) {
         //从erp中获取部门信息
         DeptRespDTO dept = deptApi.getDept(Long.valueOf(deptId));
@@ -282,7 +284,7 @@ public class ErpToEccangConverter {
         Integer pid = 0;
         //判断该品类名在易仓中是否已经存在，存在则去修改，不存在则去新增
         EccangCategory categoryByName = eccangService.getCategoryByErpDeptId(deptId);
-        if (categoryByName != null){
+        if (categoryByName != null) {
             id = categoryByName.getPcId();
             actionType = "EDIT";
         }
@@ -297,21 +299,22 @@ public class ErpToEccangConverter {
             pid = category.getPcId();
         }
         return EccangCategory.builder()
-                .actionType(actionType)
-                .pcId(id)
-                .pcName(deptName)
-                .pcNameEn(deptId)
-                .pcPid(pid)
-                .pcLevel(Math.min(deptLevel, 3))
-                .build();
+            .actionType(actionType)
+            .pcId(id)
+            .pcName(deptName)
+            .pcNameEn(deptId)
+            .pcPid(pid)
+            .pcLevel(Math.min(deptLevel, 3))
+            .build();
     }
+
     /**
-    * @Author Wqh
-    * @Description 获取父级名称
-    * @Date  2024/11/25
-    * @Param [deptTreeLevel]
-    **/
-        private DeptLevelRespDTO getParentName(Integer deptLevel, TreeSet<DeptLevelRespDTO> deptTreeLevel) {
+     * @Author Wqh
+     * @Description 获取父级名称
+     * @Date 2024/11/25
+     * @Param [deptTreeLevel]
+     **/
+    private DeptLevelRespDTO getParentName(Integer deptLevel, TreeSet<DeptLevelRespDTO> deptTreeLevel) {
         if (deptLevel > 3) {
             //向上找父类
             deptTreeLevel.pollLast();

--- a/somle-esb/src/main/java/com/somle/esb/handler/ErpCustomRuleHandler.java
+++ b/somle-esb/src/main/java/com/somle/esb/handler/ErpCustomRuleHandler.java
@@ -100,7 +100,7 @@ public class ErpCustomRuleHandler {
                         .ifPresent(eccangProduct::setProductPrice);
                 });
         }
-        List<EccangProduct> products = addOriginalProducts(eccangProducts);
+        List<EccangProduct> products = addOriginalEccangProducts(eccangProducts);
         eccangService.addBatchProduct(products);
         log.info("syncCustomRuleToEccang end ,sku={{}}", products.stream().map(EccangProduct::getProductSku).toList());
     }
@@ -131,28 +131,20 @@ public class ErpCustomRuleHandler {
      * @param eccangProducts 产品集合
      * @return 合并后的产品集合
      */
-    private List<EccangProduct> addOriginalProducts(List<EccangProduct> eccangProducts) {
-        String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
-        List<EccangProduct> additionalProducts = eccangProducts.parallelStream()
-            .filter(eccangProduct ->
-                StringUtils.isNotBlank(eccangProduct.getProductSku()) &&
-                    eccangProduct.getProductSku().endsWith(suffix)
-            )
-            .map(eccangProduct -> {
-                EccangProduct bean = BeanUtils.toBean(eccangProduct, EccangProduct.class);
-                bean.setProductSku(ConstantConvertUtils.removeSuffix(eccangProduct.getProductSku(), suffix));
-                bean.setProductTitle(ConstantConvertUtils.removeSuffix(eccangProduct.getProductTitle(), suffix));
-                bean.setProductTitleEn(ConstantConvertUtils.removeSuffix(eccangProduct.getProductTitleEn(), suffix));
-                bean.setParentProductId(null);//1、如果产品有父级，则父级为空
-                return bean;
-            })
-            .toList();
-        // 合并原集合与新增集合。多线程安全
-        CopyOnWriteArrayList<EccangProduct> mergedList = new CopyOnWriteArrayList<>(eccangProducts);
-        mergedList.addAll(additionalProducts);
-        return mergedList;
+    private List<EccangProduct> addOriginalEccangProducts(List<EccangProduct> eccangProducts) {
+        return addOriginalProducts(
+            eccangProducts,
+            EccangProduct::getProductSku,
+            EccangProduct::setProductSku,
+            EccangProduct::setProductTitle,
+            product -> product.setParentProductId(null),
+            product -> {
+                if (StringUtils.isNotBlank(product.getProductTitleEn())) {
+                    product.setProductTitleEn(ConstantConvertUtils.removeSuffix(product.getProductTitleEn(), "-" + ConstantConvertUtils.getCountrySuffix("CN")));
+                }
+            }
+        );
     }
-
     /**
      * 添加默认产品（无后缀），在集合 KingdeeProduct 中处理。
      * 如果集合中 productSku 后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。
@@ -161,24 +153,62 @@ public class ErpCustomRuleHandler {
      * @return 合并后的产品集合
      */
     private List<KingdeeProduct> addOriginalKingdeeProducts(List<KingdeeProduct> kingdeeProducts) {
-        String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
-        List<KingdeeProduct> additionalProducts = kingdeeProducts.parallelStream()
-            .filter(kingdeeProduct ->
-                StringUtils.isNotBlank(kingdeeProduct.getNumber()) &&
-                    kingdeeProduct.getNumber().endsWith(suffix)
-            )
-            .map(kingdeeProduct -> {
-                KingdeeProduct bean = BeanUtils.toBean(kingdeeProduct, KingdeeProduct.class);
-                bean.setNumber(ConstantConvertUtils.removeSuffix(kingdeeProduct.getNumber(), suffix));
-                bean.setName(ConstantConvertUtils.removeSuffix(kingdeeProduct.getName(), suffix));
-                bean.setParentId(null); // 清除上级物品编号
-                return bean;
-            })
-            .toList();
-        // 合并原集合与新增集合，多线程安全
-        CopyOnWriteArrayList<KingdeeProduct> mergedList = new CopyOnWriteArrayList<>(kingdeeProducts);
-        mergedList.addAll(additionalProducts);
-        return mergedList;
+        return addOriginalProducts(
+            kingdeeProducts,
+            KingdeeProduct::getNumber,
+            KingdeeProduct::setNumber,
+            KingdeeProduct::setName,
+            product -> product.setParentId(null),
+            null // 没有额外字段需要处理
+        );
     }
 
+
+    /**
+     * 添加默认产品（无后缀），通用方法。
+     * 如果集合中产品编号后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。
+     *
+     * @param <T>              产品类型（如 EccangProduct 或 KingdeeProduct）
+     * @param products         产品集合
+     * @param getNumber        获取编号的方法引用
+     * @param setNumber        设置编号的方法引用
+     * @param setName          设置名称的方法引用（可为 null，如果不需要处理名称）
+     * @param setParent        设置上级编号的方法引用
+     * @param additionalFields 处理其他需要移除后缀的字段的逻辑（可为空）
+     * @return 合并后的产品集合
+     */
+    @SuppressWarnings("unchecked")
+    private <T> List<T> addOriginalProducts(
+        List<T> products,
+        java.util.function.Function<T, String> getNumber,
+        java.util.function.BiConsumer<T, String> setNumber,
+        java.util.function.BiConsumer<T, String> setName,
+        java.util.function.Consumer<T> setParent,
+        java.util.function.Consumer<T> additionalFields
+    ) {
+        String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
+
+        // 过滤和转换产品
+        List<T> additionalProducts = products.stream()
+            .filter(product -> StringUtils.isNotBlank(getNumber.apply(product)) && getNumber.apply(product).endsWith(suffix))
+            .map(product -> {
+                T newProduct = BeanUtils.toBean(product, (Class<T>) product.getClass());
+                setNumber.accept(newProduct, ConstantConvertUtils.removeSuffix(getNumber.apply(product), suffix));
+                if (setName != null) {
+                    setName.accept(newProduct, ConstantConvertUtils.removeSuffix(getNumber.apply(product), suffix));
+                }
+                setParent.accept(newProduct); // 清除上级物品编号
+                if (additionalFields != null) {
+                    additionalFields.accept(newProduct); // 处理额外字段
+                }
+                return newProduct;
+            })
+            .toList();
+
+        // 合并原始集合与新增集合
+        List<T> mergedList = new CopyOnWriteArrayList<>(products);
+        mergedList.addAll(additionalProducts);
+
+        return mergedList;
+    }
 }

--- a/somle-esb/src/main/java/com/somle/esb/handler/ErpCustomRuleHandler.java
+++ b/somle-esb/src/main/java/com/somle/esb/handler/ErpCustomRuleHandler.java
@@ -1,6 +1,7 @@
 package com.somle.esb.handler;
 
 import cn.hutool.core.util.ObjUtil;
+import cn.iocoder.yudao.framework.common.util.object.BeanUtils;
 import cn.iocoder.yudao.framework.common.util.object.ObjectUtils;
 import cn.iocoder.yudao.module.erp.api.product.dto.ErpCustomRuleDTO;
 import cn.iocoder.yudao.module.erp.controller.admin.purchase.vo.ErpSupplierProductPageReqVO;
@@ -9,6 +10,7 @@ import com.somle.eccang.model.EccangProduct;
 import com.somle.eccang.service.EccangService;
 import com.somle.esb.converter.ErpToEccangConverter;
 import com.somle.esb.converter.ErpToKingdeeConverter;
+import com.somle.esb.util.ConstantConvertUtils;
 import com.somle.kingdee.model.KingdeeProduct;
 import com.somle.kingdee.service.KingdeeService;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @Description: $
@@ -47,21 +50,21 @@ public class ErpCustomRuleHandler {
     ErpToKingdeeConverter erpToKingdeeConverter;
 
     /**
+     * @return void
      * @Author Wqh
      * @Description 上传eccang产品信息
      * @Date 11:18 2024/11/5
      * @Param [message]
-     * @return void
      **/
     @ServiceActivator(inputChannel = "erpCustomRuleChannel")
     public void syncCustomRulesToEccang(@Payload List<ErpCustomRuleDTO> customRules) {
         log.info("syncCustomRuleToEccang");
         List<EccangProduct> eccangProducts = erpToEccangConverter.customRuleDTOToProduct(customRules);
-        for (EccangProduct eccangProduct : eccangProducts){
+        for (EccangProduct eccangProduct : eccangProducts) {
             eccangProduct.setActionType("ADD");
             EccangProduct eccangServiceProduct = eccangService.getProduct(eccangProduct.getProductSku());
             //根据sku从eccang中获取产品，如果产品不为空，则表示已存在，操作则变为修改
-            if (ObjUtil.isNotEmpty(eccangServiceProduct)){
+            if (ObjUtil.isNotEmpty(eccangServiceProduct)) {
                 eccangProduct.setActionType("EDIT");
                 //如果是修改就要上传默认采购单价
                 //TODO 后续有变更，请修改
@@ -97,25 +100,85 @@ public class ErpCustomRuleHandler {
                         .ifPresent(eccangProduct::setProductPrice);
                 });
         }
-        eccangService.addBatchProduct(eccangProducts);
-        log.info("syncCustomRuleToEccang end countSize{{}}",eccangProducts.size());
+        List<EccangProduct> products = addOriginalProducts(eccangProducts);
+        eccangService.addBatchProduct(products);
+        log.info("syncCustomRuleToEccang end ,sku={{}}", products.stream().map(EccangProduct::getProductSku).toList());
     }
 
     /**
+     * @return void
      * @Author Wqh
      * @Description 上传金蝶产品信息
      * @Date 11:18 2024/11/5
      * @Param [message]
-     * @return void
      **/
     @ServiceActivator(inputChannel = "erpCustomRuleChannel")
     public void syncCustomRulesToKingdee(@Payload List<ErpCustomRuleDTO> customRules) {
         log.info("syncCustomRuleToKingdee");
         List<KingdeeProduct> kingdee = erpToKingdeeConverter.customRuleDTOToProduct(customRules);
-        for (KingdeeProduct kingdeeProduct : kingdee){
+        List<KingdeeProduct> kingdeeProducts = addOriginalKingdeeProducts(kingdee);
+        for (KingdeeProduct kingdeeProduct : kingdeeProducts) {
             kingdeeService.addProduct(kingdeeProduct);
         }
-        log.info("syncCustomRuleToKingdee end");
+        log.info("syncCustomRuleToKingdee end,skus={{}}}", kingdeeProducts.stream().map(KingdeeProduct::getNumber).toList());
+    }
+
+    /**
+     * 添加默认产品（无国别），在CN中触发。
+     * <p>
+     * 如果集合 EccangProduct 中 productSku 后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。
+     *
+     * @param eccangProducts 产品集合
+     * @return 合并后的产品集合
+     */
+    private List<EccangProduct> addOriginalProducts(List<EccangProduct> eccangProducts) {
+        String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
+        List<EccangProduct> additionalProducts = eccangProducts.parallelStream()
+            .filter(eccangProduct ->
+                StringUtils.isNotBlank(eccangProduct.getProductSku()) &&
+                    eccangProduct.getProductSku().endsWith(suffix)
+            )
+            .map(eccangProduct -> {
+                EccangProduct bean = BeanUtils.toBean(eccangProduct, EccangProduct.class);
+                bean.setProductSku(ConstantConvertUtils.removeSuffix(eccangProduct.getProductSku(), suffix));
+                bean.setProductTitle(ConstantConvertUtils.removeSuffix(eccangProduct.getProductTitle(), suffix));
+                bean.setProductTitleEn(ConstantConvertUtils.removeSuffix(eccangProduct.getProductTitleEn(), suffix));
+                bean.setParentProductId(null);//1、如果产品有父级，则父级为空
+                return bean;
+            })
+            .toList();
+        // 合并原集合与新增集合。多线程安全
+        CopyOnWriteArrayList<EccangProduct> mergedList = new CopyOnWriteArrayList<>(eccangProducts);
+        mergedList.addAll(additionalProducts);
+        return mergedList;
+    }
+
+    /**
+     * 添加默认产品（无后缀），在集合 KingdeeProduct 中处理。
+     * 如果集合中 productSku 后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。
+     *
+     * @param kingdeeProducts 产品集合
+     * @return 合并后的产品集合
+     */
+    private List<KingdeeProduct> addOriginalKingdeeProducts(List<KingdeeProduct> kingdeeProducts) {
+        String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
+        List<KingdeeProduct> additionalProducts = kingdeeProducts.parallelStream()
+            .filter(kingdeeProduct ->
+                StringUtils.isNotBlank(kingdeeProduct.getNumber()) &&
+                    kingdeeProduct.getNumber().endsWith(suffix)
+            )
+            .map(kingdeeProduct -> {
+                KingdeeProduct bean = BeanUtils.toBean(kingdeeProduct, KingdeeProduct.class);
+                bean.setNumber(ConstantConvertUtils.removeSuffix(kingdeeProduct.getNumber(), suffix));
+                bean.setName(ConstantConvertUtils.removeSuffix(kingdeeProduct.getName(), suffix));
+                bean.setParentId(null); // 清除上级物品编号
+                return bean;
+            })
+            .toList();
+        // 合并原集合与新增集合，多线程安全
+        CopyOnWriteArrayList<KingdeeProduct> mergedList = new CopyOnWriteArrayList<>(kingdeeProducts);
+        mergedList.addAll(additionalProducts);
+        return mergedList;
     }
 
 }

--- a/somle-esb/src/main/java/com/somle/esb/handler/ErpCustomRuleHandler.java
+++ b/somle-esb/src/main/java/com/somle/esb/handler/ErpCustomRuleHandler.java
@@ -100,7 +100,7 @@ public class ErpCustomRuleHandler {
                         .ifPresent(eccangProduct::setProductPrice);
                 });
         }
-        List<EccangProduct> products = addOriginalEccangProducts(eccangProducts);
+        List<EccangProduct> products = addOriginalProducts(eccangProducts);
         eccangService.addBatchProduct(products);
         log.info("syncCustomRuleToEccang end ,sku={{}}", products.stream().map(EccangProduct::getProductSku).toList());
     }
@@ -131,20 +131,28 @@ public class ErpCustomRuleHandler {
      * @param eccangProducts 产品集合
      * @return 合并后的产品集合
      */
-    private List<EccangProduct> addOriginalEccangProducts(List<EccangProduct> eccangProducts) {
-        return addOriginalProducts(
-            eccangProducts,
-            EccangProduct::getProductSku,
-            EccangProduct::setProductSku,
-            EccangProduct::setProductTitle,
-            product -> product.setParentProductId(null),
-            product -> {
-                if (StringUtils.isNotBlank(product.getProductTitleEn())) {
-                    product.setProductTitleEn(ConstantConvertUtils.removeSuffix(product.getProductTitleEn(), "-" + ConstantConvertUtils.getCountrySuffix("CN")));
-                }
-            }
-        );
+    private List<EccangProduct> addOriginalProducts(List<EccangProduct> eccangProducts) {
+        String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
+        List<EccangProduct> additionalProducts = eccangProducts.parallelStream()
+            .filter(eccangProduct ->
+                StringUtils.isNotBlank(eccangProduct.getProductSku()) &&
+                    eccangProduct.getProductSku().endsWith(suffix)
+            )
+            .map(eccangProduct -> {
+                EccangProduct bean = BeanUtils.toBean(eccangProduct, EccangProduct.class);
+                bean.setProductSku(ConstantConvertUtils.removeSuffix(eccangProduct.getProductSku(), suffix));
+                bean.setProductTitle(ConstantConvertUtils.removeSuffix(eccangProduct.getProductTitle(), suffix));
+                bean.setProductTitleEn(ConstantConvertUtils.removeSuffix(eccangProduct.getProductTitleEn(), suffix));
+                bean.setParentProductId(null);//1、如果产品有父级，则父级为空
+                return bean;
+            })
+            .toList();
+        // 合并原集合与新增集合。多线程安全
+        CopyOnWriteArrayList<EccangProduct> mergedList = new CopyOnWriteArrayList<>(eccangProducts);
+        mergedList.addAll(additionalProducts);
+        return mergedList;
     }
+
     /**
      * 添加默认产品（无后缀），在集合 KingdeeProduct 中处理。
      * 如果集合中 productSku 后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。
@@ -153,62 +161,24 @@ public class ErpCustomRuleHandler {
      * @return 合并后的产品集合
      */
     private List<KingdeeProduct> addOriginalKingdeeProducts(List<KingdeeProduct> kingdeeProducts) {
-        return addOriginalProducts(
-            kingdeeProducts,
-            KingdeeProduct::getNumber,
-            KingdeeProduct::setNumber,
-            KingdeeProduct::setName,
-            product -> product.setParentId(null),
-            null // 没有额外字段需要处理
-        );
-    }
-
-
-    /**
-     * 添加默认产品（无后缀），通用方法。
-     * 如果集合中产品编号后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。
-     *
-     * @param <T>              产品类型（如 EccangProduct 或 KingdeeProduct）
-     * @param products         产品集合
-     * @param getNumber        获取编号的方法引用
-     * @param setNumber        设置编号的方法引用
-     * @param setName          设置名称的方法引用（可为 null，如果不需要处理名称）
-     * @param setParent        设置上级编号的方法引用
-     * @param additionalFields 处理其他需要移除后缀的字段的逻辑（可为空）
-     * @return 合并后的产品集合
-     */
-    @SuppressWarnings("unchecked")
-    private <T> List<T> addOriginalProducts(
-        List<T> products,
-        java.util.function.Function<T, String> getNumber,
-        java.util.function.BiConsumer<T, String> setNumber,
-        java.util.function.BiConsumer<T, String> setName,
-        java.util.function.Consumer<T> setParent,
-        java.util.function.Consumer<T> additionalFields
-    ) {
         String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
-
-        // 过滤和转换产品
-        List<T> additionalProducts = products.stream()
-            .filter(product -> StringUtils.isNotBlank(getNumber.apply(product)) && getNumber.apply(product).endsWith(suffix))
-            .map(product -> {
-                T newProduct = BeanUtils.toBean(product, (Class<T>) product.getClass());
-                setNumber.accept(newProduct, ConstantConvertUtils.removeSuffix(getNumber.apply(product), suffix));
-                if (setName != null) {
-                    setName.accept(newProduct, ConstantConvertUtils.removeSuffix(getNumber.apply(product), suffix));
-                }
-                setParent.accept(newProduct); // 清除上级物品编号
-                if (additionalFields != null) {
-                    additionalFields.accept(newProduct); // 处理额外字段
-                }
-                return newProduct;
+        List<KingdeeProduct> additionalProducts = kingdeeProducts.parallelStream()
+            .filter(kingdeeProduct ->
+                StringUtils.isNotBlank(kingdeeProduct.getNumber()) &&
+                    kingdeeProduct.getNumber().endsWith(suffix)
+            )
+            .map(kingdeeProduct -> {
+                KingdeeProduct bean = BeanUtils.toBean(kingdeeProduct, KingdeeProduct.class);
+                bean.setNumber(ConstantConvertUtils.removeSuffix(kingdeeProduct.getNumber(), suffix));
+                bean.setName(ConstantConvertUtils.removeSuffix(kingdeeProduct.getName(), suffix));
+                bean.setParentId(null); // 清除上级物品编号
+                return bean;
             })
             .toList();
-
-        // 合并原始集合与新增集合
-        List<T> mergedList = new CopyOnWriteArrayList<>(products);
+        // 合并原集合与新增集合，多线程安全
+        CopyOnWriteArrayList<KingdeeProduct> mergedList = new CopyOnWriteArrayList<>(kingdeeProducts);
         mergedList.addAll(additionalProducts);
-
         return mergedList;
     }
+
 }

--- a/somle-esb/src/main/java/com/somle/esb/handler/ErpCustomRuleHandler.java
+++ b/somle-esb/src/main/java/com/somle/esb/handler/ErpCustomRuleHandler.java
@@ -6,16 +6,16 @@ import cn.iocoder.yudao.framework.common.util.object.ObjectUtils;
 import cn.iocoder.yudao.module.erp.api.product.dto.ErpCustomRuleDTO;
 import cn.iocoder.yudao.module.erp.controller.admin.purchase.vo.ErpSupplierProductPageReqVO;
 import cn.iocoder.yudao.module.erp.service.purchase.ErpSupplierProductService;
+import cn.iocoder.yudao.module.system.api.dict.DictDataApi;
 import com.somle.eccang.model.EccangProduct;
 import com.somle.eccang.service.EccangService;
 import com.somle.esb.converter.ErpToEccangConverter;
 import com.somle.esb.converter.ErpToKingdeeConverter;
-import com.somle.esb.util.ConstantConvertUtils;
 import com.somle.kingdee.model.KingdeeProduct;
 import com.somle.kingdee.service.KingdeeService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
@@ -33,21 +33,15 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class ErpCustomRuleHandler {
 
-    @Autowired
-    KingdeeService kingdeeService;
-
-    @Autowired
-    EccangService eccangService;
-
-    @Autowired
-    ErpSupplierProductService erpSupplierProductService;
-    @Autowired
-    ErpToEccangConverter erpToEccangConverter;
-
-    @Autowired
-    ErpToKingdeeConverter erpToKingdeeConverter;
+    private final KingdeeService kingdeeService;
+    private final EccangService eccangService;
+    private final ErpSupplierProductService erpSupplierProductService;
+    private final ErpToEccangConverter erpToEccangConverter;
+    private final ErpToKingdeeConverter erpToKingdeeConverter;
+    private final DictDataApi dictDataApi;
 
     /**
      * @return void
@@ -58,8 +52,8 @@ public class ErpCustomRuleHandler {
      **/
     @ServiceActivator(inputChannel = "erpCustomRuleChannel")
     public void syncCustomRulesToEccang(@Payload List<ErpCustomRuleDTO> customRules) {
-        log.info("syncCustomRuleToEccang");
-        List<EccangProduct> eccangProducts = erpToEccangConverter.customRuleDTOToProduct(customRules);
+        log.info("syncCustomRuleToEccang start, sku={{}}", customRules.stream().map(ErpCustomRuleDTO::getBarCode).toList());
+        List<EccangProduct> eccangProducts = erpToEccangConverter.customRuleDTOToProduct(processCustomRules(customRules));
         for (EccangProduct eccangProduct : eccangProducts) {
             eccangProduct.setActionType("ADD");
             EccangProduct eccangServiceProduct = eccangService.getProduct(eccangProduct.getProductSku());
@@ -100,9 +94,8 @@ public class ErpCustomRuleHandler {
                         .ifPresent(eccangProduct::setProductPrice);
                 });
         }
-        List<EccangProduct> products = addOriginalProducts(eccangProducts);
-        eccangService.addBatchProduct(products);
-        log.info("syncCustomRuleToEccang end ,sku={{}}", products.stream().map(EccangProduct::getProductSku).toList());
+        eccangService.addBatchProduct(eccangProducts);
+        log.info("syncCustomRuleToEccang end ,sku={{}}", eccangProducts.stream().map(EccangProduct::getProductSku).toList());
     }
 
     /**
@@ -115,70 +108,34 @@ public class ErpCustomRuleHandler {
     @ServiceActivator(inputChannel = "erpCustomRuleChannel")
     public void syncCustomRulesToKingdee(@Payload List<ErpCustomRuleDTO> customRules) {
         log.info("syncCustomRuleToKingdee");
-        List<KingdeeProduct> kingdee = erpToKingdeeConverter.customRuleDTOToProduct(customRules);
-        List<KingdeeProduct> kingdeeProducts = addOriginalKingdeeProducts(kingdee);
-        for (KingdeeProduct kingdeeProduct : kingdeeProducts) {
+        List<KingdeeProduct> kingdee = erpToKingdeeConverter.customRuleDTOToProduct(processCustomRules(customRules));
+        for (KingdeeProduct kingdeeProduct : kingdee) {
             kingdeeService.addProduct(kingdeeProduct);
         }
-        log.info("syncCustomRuleToKingdee end,skus={{}}}", kingdeeProducts.stream().map(KingdeeProduct::getNumber).toList());
+        log.info("syncCustomRuleToKingdee end,skus={{}}}", kingdee.stream().map(KingdeeProduct::getNumber).toList());
     }
+
 
     /**
-     * 添加默认产品（无国别），在CN中触发。
-     * <p>
-     * 如果集合 EccangProduct 中 productSku 后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。
+     * 处理自定义规则列表，复制 countryCode 为 CN 字典映射值的对象
      *
-     * @param eccangProducts 产品集合
-     * @return 合并后的产品集合
+     * @param customRules 原始海关规则列表
+     * @return 处理后的海关规则列表 List<ErpCustomRuleDTO>
      */
-    private List<EccangProduct> addOriginalProducts(List<EccangProduct> eccangProducts) {
-        String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
-        List<EccangProduct> additionalProducts = eccangProducts.parallelStream()
-            .filter(eccangProduct ->
-                StringUtils.isNotBlank(eccangProduct.getProductSku()) &&
-                    eccangProduct.getProductSku().endsWith(suffix)
-            )
-            .map(eccangProduct -> {
-                EccangProduct bean = BeanUtils.toBean(eccangProduct, EccangProduct.class);
-                bean.setProductSku(ConstantConvertUtils.removeSuffix(eccangProduct.getProductSku(), suffix));
-                bean.setProductTitle(ConstantConvertUtils.removeSuffix(eccangProduct.getProductTitle(), suffix));
-                bean.setProductTitleEn(ConstantConvertUtils.removeSuffix(eccangProduct.getProductTitleEn(), suffix));
-                bean.setParentProductId(null);//1、如果产品有父级，则父级为空
-                return bean;
-            })
-            .toList();
-        // 合并原集合与新增集合。多线程安全
-        CopyOnWriteArrayList<EccangProduct> mergedList = new CopyOnWriteArrayList<>(eccangProducts);
-        mergedList.addAll(additionalProducts);
-        return mergedList;
+    private List<ErpCustomRuleDTO> processCustomRules(List<ErpCustomRuleDTO> customRules) {
+        CopyOnWriteArrayList<ErpCustomRuleDTO> processedRules = new CopyOnWriteArrayList<>(customRules);
+        customRules.stream()
+            .filter(customRule -> customRule.getCountryCode() != null)
+            .forEach(customRule -> Optional.ofNullable(dictDataApi.parseDictData("country_code", "CN"))
+                .flatMap(dictDataRespDTO -> Optional.ofNullable(dictDataRespDTO.getValue()))
+                .ifPresent(value -> {
+                    Integer countryCode = Integer.valueOf(value);
+                    if (customRule.getCountryCode().equals(countryCode)) {
+                        //当前存在国家是CN的数据
+                        ErpCustomRuleDTO bean = BeanUtils.toBean(customRule, ErpCustomRuleDTO.class);
+                        processedRules.add(BeanUtils.toBean(bean.setCountryCode(null), ErpCustomRuleDTO.class));
+                    }
+                }));
+        return processedRules;
     }
-
-    /**
-     * 添加默认产品（无后缀），在集合 KingdeeProduct 中处理。
-     * 如果集合中 productSku 后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。
-     *
-     * @param kingdeeProducts 产品集合
-     * @return 合并后的产品集合
-     */
-    private List<KingdeeProduct> addOriginalKingdeeProducts(List<KingdeeProduct> kingdeeProducts) {
-        String suffix = "-" + ConstantConvertUtils.getCountrySuffix("CN");
-        List<KingdeeProduct> additionalProducts = kingdeeProducts.parallelStream()
-            .filter(kingdeeProduct ->
-                StringUtils.isNotBlank(kingdeeProduct.getNumber()) &&
-                    kingdeeProduct.getNumber().endsWith(suffix)
-            )
-            .map(kingdeeProduct -> {
-                KingdeeProduct bean = BeanUtils.toBean(kingdeeProduct, KingdeeProduct.class);
-                bean.setNumber(ConstantConvertUtils.removeSuffix(kingdeeProduct.getNumber(), suffix));
-                bean.setName(ConstantConvertUtils.removeSuffix(kingdeeProduct.getName(), suffix));
-                bean.setParentId(null); // 清除上级物品编号
-                return bean;
-            })
-            .toList();
-        // 合并原集合与新增集合，多线程安全
-        CopyOnWriteArrayList<KingdeeProduct> mergedList = new CopyOnWriteArrayList<>(kingdeeProducts);
-        mergedList.addAll(additionalProducts);
-        return mergedList;
-    }
-
 }

--- a/somle-esb/src/main/java/com/somle/esb/util/ConstantConvertUtils.java
+++ b/somle-esb/src/main/java/com/somle/esb/util/ConstantConvertUtils.java
@@ -1,5 +1,7 @@
 package com.somle.esb.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * @className: ConstantConverUtil
  * @author: Wqh
@@ -27,5 +29,18 @@ public final class ConstantConvertUtils {
             case "SA" -> "KSA";
             default -> countryCode;
         };
+    }
+    /**
+     * 去掉字符串的指定后缀（如果存在）。
+     *
+     * @param value 原字符串
+     * @param suffix 后缀
+     * @return 去掉后缀的字符串
+     */
+    public static String removeSuffix(String value, String suffix) {
+        if (StringUtils.isNotBlank(value) && value.endsWith(suffix)) {
+            return value.substring(0, value.length() - suffix.length());
+        }
+        return value;
     }
 }

--- a/somle-esb/src/main/java/com/somle/esb/util/ConstantConvertUtils.java
+++ b/somle-esb/src/main/java/com/somle/esb/util/ConstantConvertUtils.java
@@ -1,6 +1,5 @@
 package com.somle.esb.util;
 
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * @className: ConstantConverUtil
@@ -29,18 +28,5 @@ public final class ConstantConvertUtils {
             case "SA" -> "KSA";
             default -> countryCode;
         };
-    }
-    /**
-     * 去掉字符串的指定后缀（如果存在）。
-     *
-     * @param value 原字符串
-     * @param suffix 后缀
-     * @return 去掉后缀的字符串
-     */
-    public static String removeSuffix(String value, String suffix) {
-        if (StringUtils.isNotBlank(value) && value.endsWith(suffix)) {
-            return value.substring(0, value.length() - suffix.length());
-        }
-        return value;
     }
 }

--- a/yudao-module-erp/yudao-module-erp-biz/src/main/java/cn/iocoder/yudao/module/erp/service/product/ErpProductServiceImpl.java
+++ b/yudao-module-erp/yudao-module-erp-biz/src/main/java/cn/iocoder/yudao/module/erp/service/product/ErpProductServiceImpl.java
@@ -124,7 +124,7 @@ public class ErpProductServiceImpl implements ErpProductService {
         ErpProductDTO erpProductDTO = BeanUtils.toBean(product, ErpProductDTO.class);
         erpProductDTO.setCreator(String.valueOf(loginUserId));
         //同步数据,根据需求文档，新增的时候不同步产品信息(不带国别)。海关规则加CN规则的时候同步。
-//        erpProductChannel.send(MessageBuilder.withPayload(List.of(erpProductDTO)).build());
+        erpProductChannel.send(MessageBuilder.withPayload(List.of(erpProductDTO)).build());
         // 返回
         return product.getId();
     }
@@ -178,7 +178,7 @@ public class ErpProductServiceImpl implements ErpProductService {
         ThrowUtil.ifSqlThrow(productMapper.updateById(updateObj),DB_UPDATE_ERROR);
         //同步数据
         var dtos = customRuleMapper.selectProductAllInfoListById(id);
-        erpCustomRuleChannel.send(MessageBuilder.withPayload(dtos).build());
+//        erpCustomRuleChannel.send(MessageBuilder.withPayload(dtos).build());
 
         //获取创建人id
         Long loginUserId = SecurityFrameworkUtils.getLoginUserId();

--- a/yudao-module-erp/yudao-module-erp-biz/src/main/java/cn/iocoder/yudao/module/erp/service/product/ErpProductServiceImpl.java
+++ b/yudao-module-erp/yudao-module-erp-biz/src/main/java/cn/iocoder/yudao/module/erp/service/product/ErpProductServiceImpl.java
@@ -123,7 +123,7 @@ public class ErpProductServiceImpl implements ErpProductService {
         Long loginUserId = SecurityFrameworkUtils.getLoginUserId();
         ErpProductDTO erpProductDTO = BeanUtils.toBean(product, ErpProductDTO.class);
         erpProductDTO.setCreator(String.valueOf(loginUserId));
-        //同步数据,根据需求文档，新增的时候不同步产品信息(不带国别)。海关规则加CN规则的时候同步。
+        //同步数据
         erpProductChannel.send(MessageBuilder.withPayload(List.of(erpProductDTO)).build());
         // 返回
         return product.getId();
@@ -176,7 +176,7 @@ public class ErpProductServiceImpl implements ErpProductService {
             updateObj.setPatentCountryCodes("");
         }
         ThrowUtil.ifSqlThrow(productMapper.updateById(updateObj),DB_UPDATE_ERROR);
-        //同步数据
+        //同步数据,根据需求文档，新增的时候不同步产品信息(不带国别)。海关规则加CN规则的时候同步。
         var dtos = customRuleMapper.selectProductAllInfoListById(id);
 //        erpCustomRuleChannel.send(MessageBuilder.withPayload(dtos).build());
 

--- a/yudao-module-erp/yudao-module-erp-biz/src/main/java/cn/iocoder/yudao/module/erp/service/product/ErpProductServiceImpl.java
+++ b/yudao-module-erp/yudao-module-erp-biz/src/main/java/cn/iocoder/yudao/module/erp/service/product/ErpProductServiceImpl.java
@@ -123,8 +123,8 @@ public class ErpProductServiceImpl implements ErpProductService {
         Long loginUserId = SecurityFrameworkUtils.getLoginUserId();
         ErpProductDTO erpProductDTO = BeanUtils.toBean(product, ErpProductDTO.class);
         erpProductDTO.setCreator(String.valueOf(loginUserId));
-        //同步数据
-        erpProductChannel.send(MessageBuilder.withPayload(List.of(erpProductDTO)).build());
+        //同步数据,根据需求文档，新增的时候不同步产品信息(不带国别)。海关规则加CN规则的时候同步。
+//        erpProductChannel.send(MessageBuilder.withPayload(List.of(erpProductDTO)).build());
         // 返回
         return product.getId();
     }

--- a/yudao-module-erp/yudao-module-erp-biz/src/main/java/cn/iocoder/yudao/module/erp/service/product/ErpProductServiceImpl.java
+++ b/yudao-module-erp/yudao-module-erp-biz/src/main/java/cn/iocoder/yudao/module/erp/service/product/ErpProductServiceImpl.java
@@ -79,7 +79,7 @@ public class ErpProductServiceImpl implements ErpProductService {
 
     public void validateFields(ErpProductSaveReqVO saveReqVO) {
         BeanUtils.areAllNonNullFieldsPresent(saveReqVO, ErpProductBO.class);
-    };
+    }
 
     @Override
     public Long createProduct(ErpProductSaveReqVO createReqVO) {


### PR DESCRIPTION
添加默认产品（无后缀），在集合 KingdeeProduct 中处理。
如果集合中 productSku 后缀是 "-CHN"，那么在集合中添加去掉后缀的产品。

总结：对于CN海关规则的修改+新增，如果改了CN规则，就会顺带覆盖基类产品(无国别)，然后上传到金蝶+易仓