### PR TITLE
fix somle-main-dev(test+dev)配置dev或test环境的日志级别

### DIFF
--- a/yudao-module-erp/yudao-module-erp-biz/pom.xml
+++ b/yudao-module-erp/yudao-module-erp-biz/pom.xml
@@ -85,7 +85,6 @@
             <scope>test</scope>
         </dependency>
 
-
     </dependencies>
 
 </project>

--- a/yudao-module-erp/yudao-module-erp-biz/pom.xml
+++ b/yudao-module-erp/yudao-module-erp-biz/pom.xml
@@ -63,12 +63,6 @@
             <groupId>cn.iocoder.boot</groupId>
             <artifactId>yudao-spring-boot-starter-test</artifactId>
         </dependency>
-        <!-- 热部署 -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <optional>true</optional>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.integration</groupId>

--- a/yudao-module-erp/yudao-module-erp-biz/pom.xml
+++ b/yudao-module-erp/yudao-module-erp-biz/pom.xml
@@ -63,6 +63,12 @@
             <groupId>cn.iocoder.boot</groupId>
             <artifactId>yudao-spring-boot-starter-test</artifactId>
         </dependency>
+        <!-- 热部署 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.integration</groupId>
@@ -84,6 +90,7 @@
             <version>2.2.0-snapshot</version>
             <scope>test</scope>
         </dependency>
+
 
     </dependencies>
 

--- a/yudao-server/src/main/resources/logback-spring.xml
+++ b/yudao-server/src/main/resources/logback-spring.xml
@@ -84,5 +84,8 @@
         <logger name="com.somle.esb.job" level="DEBUG" additivity="false">
             <appender-ref ref="STDOUT"/>
         </logger>
+        <logger name="cn.iocoder.yudao.module.erp.service" level="DEBUG" additivity="false">
+            <appender-ref ref="STDOUT"/>
+        </logger>
     </springProfile>
 </configuration>

--- a/yudao-server/src/main/resources/logback-spring.xml
+++ b/yudao-server/src/main/resources/logback-spring.xml
@@ -66,12 +66,23 @@
         </root>
     </springProfile>
     <!-- 其它环境 -->
-    <springProfile name="dev,test,stage,prod,default">
+    <springProfile name="stage,prod,default">
         <root level="INFO">
             <appender-ref ref="STDOUT"/>
             <appender-ref ref="ASYNC"/>
             <appender-ref ref="GRPC"/>
         </root>
     </springProfile>
-
+    <!-- 开发、测试环境 -->
+    <springProfile name="dev,test">
+        <root level="INFO">
+            <appender-ref ref="STDOUT"/>
+        </root>
+        <logger name="com.somle.framework.common.util.web.WebUtils" level="DEBUG" additivity="false">
+            <appender-ref ref="STDOUT"/>
+        </logger>
+        <logger name="com.somle.esb.job" level="DEBUG" additivity="false">
+            <appender-ref ref="STDOUT"/>
+        </logger>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
fix 增加erp模块热部署，增加http调用+job的debug级别日志（开发测试环境）。
package 打包时，不包含 devtools 工具。
生产环境 devtools 将被禁用，如 java -jar 方式或者自定义的类加载器等都会识别为生产环境。